### PR TITLE
Update HelperComponents.js

### DIFF
--- a/src/HelperComponents.js
+++ b/src/HelperComponents.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const WrappedComponent = ({ toggleMenus, component, label }) => {
   const TriggerComponent = component;


### PR DESCRIPTION
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs